### PR TITLE
Update timestamps to use localDateTime to match NOMIS

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/sync/SyncGeneralLedgerBalanceRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/sync/SyncGeneralLedgerBalanceRequest.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync
 
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
-import java.time.OffsetDateTime
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Schema(description = "Request body for synchronizing general ledger balances from an external system.")
@@ -17,10 +17,10 @@ data class SyncGeneralLedgerBalanceRequest(
 
   @Schema(
     description = "The timestamp when these general ledger balances were generated or last updated in the source system (ISO 8601 format).",
-    example = "2024-06-18T14:30:00.123456Z",
+    example = "2024-06-18T14:30:00.123456",
     required = true,
   )
-  val timestamp: OffsetDateTime,
+  val timestamp: LocalDateTime,
 
   @Schema(description = "A list of individual general ledger account balances.")
   @field:Valid

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/sync/SyncGeneralLedgerTransactionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/sync/SyncGeneralLedgerTransactionRequest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Size
-import java.time.OffsetDateTime
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Schema(description = "Request body for synchronizing general ledger transactions. Please note these are for non-offender accounts only.")
@@ -30,14 +30,14 @@ data class SyncGeneralLedgerTransactionRequest(
   @Schema(description = "The transaction type", example = "GJ", required = true)
   val transactionType: String,
 
-  @Schema(description = "The full timestamp of the transaction (ISO 8601).", example = "2011-09-30T09:08:08.671682Z", required = true)
-  val transactionTimestamp: OffsetDateTime,
+  @Schema(description = "The full timestamp of the transaction (ISO 8601).", example = "2011-09-30T09:08:08.671682", required = true)
+  val transactionTimestamp: LocalDateTime,
 
   @Schema(
     description = "The date and time the transaction was created.",
-    example = "2024-06-18T14:30:00.123456Z",
+    example = "2024-06-18T14:30:00.123456",
   )
-  val createdAt: OffsetDateTime,
+  val createdAt: LocalDateTime,
 
   @Schema(
     description = "The user ID of the person who created the transaction in the source system.",
@@ -55,9 +55,9 @@ data class SyncGeneralLedgerTransactionRequest(
 
   @Schema(
     description = "The date and time the transaction was last modified. Only provided if the transaction has been modified since creation. (ISO 8601 format with offset)",
-    example = "2022-07-15T23:03:01.123456Z",
+    example = "2022-07-15T23:03:01.123456",
   )
-  val lastModifiedAt: OffsetDateTime?,
+  val lastModifiedAt: LocalDateTime?,
 
   @Schema(
     description = "The user ID of the person who last modified the transaction. Required if lastModifiedAt has been supplied.",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/sync/SyncOffenderTransactionRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/sync/SyncOffenderTransactionRequest.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Size
-import java.time.OffsetDateTime
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Schema(description = "Request body for synchronizing an offender financial transaction.")
@@ -31,16 +31,16 @@ data class SyncOffenderTransactionRequest(
 
   @Schema(
     description = "The timestamp when this transaction occurred (ISO 8601 format).",
-    example = "2024-06-18T14:30:00.123456Z",
+    example = "2024-06-18T14:30:00.123456",
     required = true,
   )
-  val transactionTimestamp: OffsetDateTime,
+  val transactionTimestamp: LocalDateTime,
 
   @Schema(
     description = "The date and time the transaction was created.",
-    example = "2024-06-18T14:30:00.123456Z",
+    example = "2024-06-18T14:30:00.123456",
   )
-  val createdAt: OffsetDateTime,
+  val createdAt: LocalDateTime,
 
   @Schema(
     description = "The user id of the person who created the transaction.",
@@ -58,9 +58,9 @@ data class SyncOffenderTransactionRequest(
 
   @Schema(
     description = "The date and time the transaction was last modified. Only provided if the transaction has been modified since creation.",
-    example = "2022-07-15T23:03:01.123456Z",
+    example = "2022-07-15T23:03:01.123456",
   )
-  val lastModifiedAt: OffsetDateTime?,
+  val lastModifiedAt: LocalDateTime?,
 
   @Schema(
     description = "The user id of the person who last modified the transaction. Required if lastModifiedAt has been supplied.",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/controllers/SyncControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/controllers/SyncControllerTest.kt
@@ -22,7 +22,7 @@ import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync.SyncOffend
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync.SyncTransactionReceipt
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.services.SyncService
 import java.math.BigDecimal
-import java.time.OffsetDateTime
+import java.time.LocalDateTime
 import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
@@ -44,8 +44,8 @@ class SyncControllerTest {
       transactionId = 19228028,
       requestId = UUID.randomUUID(),
       caseloadId = "GMI",
-      transactionTimestamp = OffsetDateTime.now(),
-      createdAt = OffsetDateTime.now(),
+      transactionTimestamp = LocalDateTime.now(),
+      createdAt = LocalDateTime.now(),
       createdBy = "JD12345",
       createdByDisplayName = "J Doe",
       lastModifiedAt = null,
@@ -72,7 +72,7 @@ class SyncControllerTest {
     )
     dummyGeneralLedgerBalanceRequest = SyncGeneralLedgerBalanceRequest(
       requestId = UUID.randomUUID(),
-      timestamp = OffsetDateTime.now(),
+      timestamp = LocalDateTime.now(),
       balances = listOf(
         GeneralLedgerAccountBalance(code = 1101, name = "Bank", balance = BigDecimal("12.50")),
       ),
@@ -84,8 +84,8 @@ class SyncControllerTest {
       reference = "REF12345",
       caseloadId = "GMI",
       transactionType = "GJ",
-      transactionTimestamp = OffsetDateTime.now(),
-      createdAt = OffsetDateTime.now(),
+      transactionTimestamp = LocalDateTime.now(),
+      createdAt = LocalDateTime.now(),
       createdBy = "JD12345",
       createdByDisplayName = "J Doe",
       lastModifiedAt = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/integration/controllers/SyncGeneralLedgerBalanceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/integration/controllers/SyncGeneralLedgerBalanceTest.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.integration.Integratio
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync.GeneralLedgerAccountBalance
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync.SyncGeneralLedgerBalanceRequest
 import java.math.BigDecimal
-import java.time.OffsetDateTime
+import java.time.LocalDateTime
 import java.util.UUID
 
 class SyncGeneralLedgerBalanceTest : IntegrationTestBase() {
@@ -61,7 +61,7 @@ class SyncGeneralLedgerBalanceTest : IntegrationTestBase() {
   @Test
   fun `400 Bad Request - missing required requestId`() {
     val invalidMap = mapOf(
-      "timestamp" to OffsetDateTime.now(),
+      "timestamp" to LocalDateTime.now(),
       "balances" to emptyList<Any>(),
     )
     val invalidJson = objectMapper.writeValueAsString(invalidMap)
@@ -89,7 +89,7 @@ class SyncGeneralLedgerBalanceTest : IntegrationTestBase() {
   fun `400 Bad Request - missing balances`() {
     val invalidMap = mapOf(
       "requestId" to UUID.randomUUID(),
-      "timestamp" to OffsetDateTime.now(),
+      "timestamp" to LocalDateTime.now(),
     )
     val invalidJson = objectMapper.writeValueAsString(invalidMap)
 
@@ -114,7 +114,7 @@ class SyncGeneralLedgerBalanceTest : IntegrationTestBase() {
 
   private fun createSyncGeneralLedgerBalanceRequest(): SyncGeneralLedgerBalanceRequest = SyncGeneralLedgerBalanceRequest(
     requestId = UUID.randomUUID(),
-    timestamp = OffsetDateTime.now(),
+    timestamp = LocalDateTime.now(),
     balances = listOf(
       GeneralLedgerAccountBalance(code = 1101, name = "Bank", balance = BigDecimal("12.50")),
     ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/integration/controllers/SyncGeneralLedgerTransactionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/integration/controllers/SyncGeneralLedgerTransactionTest.kt
@@ -9,7 +9,7 @@ import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.config.ROLE_PRISONER_F
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync.GeneralLedgerEntry
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync.SyncGeneralLedgerTransactionRequest
-import java.time.OffsetDateTime
+import java.time.LocalDateTime
 import java.util.UUID
 
 class SyncGeneralLedgerTransactionTest : IntegrationTestBase() {
@@ -64,8 +64,8 @@ class SyncGeneralLedgerTransactionTest : IntegrationTestBase() {
       "caseloadId" to "GMI",
       "description" to "General Ledger Account Transfer",
       "transactionType" to "GJ",
-      "transactionTimestamp" to OffsetDateTime.now(),
-      "createdAt" to OffsetDateTime.now(),
+      "transactionTimestamp" to LocalDateTime.now(),
+      "createdAt" to LocalDateTime.now(),
       "createdBy" to "TESTUSER",
       "createdByDisplayName" to "Test User",
       "generalLedgerEntries" to emptyList<Any>(),
@@ -118,8 +118,8 @@ class SyncGeneralLedgerTransactionTest : IntegrationTestBase() {
     reference = "REF12345",
     caseloadId = "GMI",
     transactionType = "GJ",
-    transactionTimestamp = OffsetDateTime.now(),
-    createdAt = OffsetDateTime.now(),
+    transactionTimestamp = LocalDateTime.now(),
+    createdAt = LocalDateTime.now(),
     createdBy = "JD12345",
     createdByDisplayName = "J Doe",
     lastModifiedAt = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/integration/controllers/SyncOffenderTransactionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/integration/controllers/SyncOffenderTransactionTest.kt
@@ -10,7 +10,7 @@ import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.integration.Integratio
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync.GeneralLedgerEntry
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync.OffenderTransaction
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync.SyncOffenderTransactionRequest
-import java.time.OffsetDateTime
+import java.time.LocalDateTime
 import java.util.UUID
 
 class SyncOffenderTransactionTest : IntegrationTestBase() {
@@ -63,8 +63,8 @@ class SyncOffenderTransactionTest : IntegrationTestBase() {
     val invalidMap = mapOf(
       "transactionId" to 1234,
       "caseloadId" to "GMI",
-      "transactionTimestamp" to OffsetDateTime.now(),
-      "createdAt" to OffsetDateTime.now(),
+      "transactionTimestamp" to LocalDateTime.now(),
+      "createdAt" to LocalDateTime.now(),
       "createdBy" to "TESTUSER",
       "createdByDisplayName" to "Test User",
       "offenderTransactions" to emptyList<Any>(),
@@ -113,8 +113,8 @@ class SyncOffenderTransactionTest : IntegrationTestBase() {
     transactionId = (1..Long.MAX_VALUE).random(),
     requestId = UUID.randomUUID(),
     caseloadId = "GMI",
-    transactionTimestamp = OffsetDateTime.now(),
-    createdAt = OffsetDateTime.now().minusHours(1),
+    transactionTimestamp = LocalDateTime.now(),
+    createdAt = LocalDateTime.now().minusHours(1),
     createdBy = "JD12345",
     createdByDisplayName = "J Doe",
     lastModifiedAt = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/services/RequestCaptureServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/services/RequestCaptureServiceTest.kt
@@ -27,7 +27,6 @@ import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync.SyncGenera
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync.SyncOffenderTransactionRequest
 import java.math.BigDecimal
 import java.time.LocalDateTime
-import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit
 import java.util.UUID
 
@@ -56,8 +55,8 @@ class RequestCaptureServiceTest {
       transactionId = 19228028,
       requestId = UUID.fromString("a1b2c3d4-e5f6-7890-1234-567890abcdef"),
       caseloadId = "GMI",
-      transactionTimestamp = OffsetDateTime.now(),
-      createdAt = OffsetDateTime.now(),
+      transactionTimestamp = LocalDateTime.now(),
+      createdAt = LocalDateTime.now(),
       createdBy = "JD12345",
       createdByDisplayName = "J Doe",
       lastModifiedAt = null,
@@ -84,7 +83,7 @@ class RequestCaptureServiceTest {
     )
     dummyGeneralLedgerBalanceRequest = SyncGeneralLedgerBalanceRequest(
       requestId = UUID.fromString("b2c3d4e5-f6a7-8901-2345-67890abcdef0"),
-      timestamp = OffsetDateTime.now(),
+      timestamp = LocalDateTime.now(),
       balances = listOf(
         GeneralLedgerAccountBalance(code = 1101, name = "Bank", balance = BigDecimal("12.50")),
       ),
@@ -96,8 +95,8 @@ class RequestCaptureServiceTest {
       reference = "REF12345",
       caseloadId = "MDI",
       transactionType = "GJ",
-      transactionTimestamp = OffsetDateTime.now(),
-      createdAt = OffsetDateTime.now(),
+      transactionTimestamp = LocalDateTime.now(),
+      createdAt = LocalDateTime.now(),
       createdBy = "JD12346",
       createdByDisplayName = "J. Smith",
       lastModifiedAt = null,


### PR DESCRIPTION
NOMIS stores the timestamps as UK local time (no time zone)
Update the sync api contract to match - We will have to accept some of them will be wrong around DST transitions.