### PR TITLE
Add paging to GET endpoints to retrieve transactions by date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/controllers/sync/SyncController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/controllers/sync/SyncController.kt
@@ -196,9 +196,19 @@ class SyncController(
   fun getGeneralLedgerTransactionsByDate(
     @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,
     @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate,
+    @RequestParam(defaultValue = "0") page: Int,
+    @RequestParam(defaultValue = "20") size: Int,
   ): ResponseEntity<SyncGeneralLedgerTransactionListResponse> {
-    val transactions = syncQueryService.getGeneralLedgerTransactionsByDate(startDate, endDate)
-    val response = SyncGeneralLedgerTransactionListResponse(transactions)
+    val transactionsPage = syncQueryService.getGeneralLedgerTransactionsByDate(startDate, endDate, page, size)
+
+    val response = SyncGeneralLedgerTransactionListResponse(
+      transactions = transactionsPage.content,
+      page = transactionsPage.number,
+      totalElements = transactionsPage.totalElements,
+      totalPages = transactionsPage.totalPages,
+      last = transactionsPage.isLast,
+    )
+
     return ResponseEntity.ok(response)
   }
 
@@ -241,9 +251,18 @@ class SyncController(
   fun getOffenderTransactionsByDate(
     @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,
     @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate,
+    @RequestParam(defaultValue = "0") page: Int,
+    @RequestParam(defaultValue = "20") size: Int,
   ): ResponseEntity<SyncOffenderTransactionListResponse> {
-    val transactions = syncQueryService.getOffenderTransactionsByDate(startDate, endDate)
-    val response = SyncOffenderTransactionListResponse(transactions)
+    val transactionsPage = syncQueryService.getOffenderTransactionsByDate(startDate, endDate, page, size)
+
+    val response = SyncOffenderTransactionListResponse(
+      offenderTransactions = transactionsPage.content,
+      page = transactionsPage.number,
+      totalElements = transactionsPage.totalElements,
+      totalPages = transactionsPage.totalPages,
+      last = transactionsPage.isLast,
+    )
     return ResponseEntity.ok(response)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/jpa/repositories/NomisSyncPayloadRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/jpa/repositories/NomisSyncPayloadRepository.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.prisonerfinancepocapi.jpa.repositories
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -31,7 +33,8 @@ interface NomisSyncPayloadRepository : JpaRepository<NomisSyncPayload, Long> {
     @Param("startDate") startDate: LocalDateTime,
     @Param("endDate") endDate: LocalDateTime,
     @Param("requestTypeIdentifier") requestTypeIdentifier: String,
-  ): List<NomisSyncPayload>
+    pageable: Pageable,
+  ): Page<NomisSyncPayload>
 
   fun findFirstBySynchronizedTransactionIdOrderByTimestampDesc(synchronizedTransactionId: UUID): NomisSyncPayload?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/sync/SyncGeneralLedgerTransactionListResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/sync/SyncGeneralLedgerTransactionListResponse.kt
@@ -6,8 +6,21 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(description = "A response containing a list of general ledger transactions.")
 data class SyncGeneralLedgerTransactionListResponse(
   @field:ArraySchema(
-    arraySchema = Schema(description = "The list of general ledger transactions found for the specified date range."),
+    arraySchema = Schema(description = "The list of general ledger transactions on the current page"),
     schema = Schema(implementation = SyncGeneralLedgerTransactionResponse::class),
   )
   val transactions: List<SyncGeneralLedgerTransactionResponse>,
+
+  @field:Schema(description = "The current page number (0-indexed).")
+  val page: Int,
+
+  @field:Schema(description = "The total number of elements across all pages.")
+  val totalElements: Long,
+
+  @field:Schema(description = "The total number of pages.")
+  val totalPages: Int,
+
+  @field:Schema(description = "Indicates if this is the last page.")
+  val last: Boolean,
+
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/sync/SyncOffenderTransactionListResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/sync/SyncOffenderTransactionListResponse.kt
@@ -1,12 +1,24 @@
 package uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync
 
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 
-@Schema(description = "A response containing a list of offender transactions.")
 data class SyncOffenderTransactionListResponse(
-  @field:Schema(
-    description = "The list of transactions found for the specified offender and date range.",
-    required = true,
+  @field:ArraySchema(
+    arraySchema = Schema(description = "The list of offender transactions on the current page"),
+    schema = Schema(implementation = SyncOffenderTransactionResponse::class),
   )
   val offenderTransactions: List<SyncOffenderTransactionResponse>,
+
+  @field:Schema(description = "The current page number (0-indexed).")
+  val page: Int,
+
+  @field:Schema(description = "The total number of elements across all pages.")
+  val totalElements: Long,
+
+  @field:Schema(description = "The total number of pages.")
+  val totalPages: Int,
+
+  @field:Schema(description = "Indicates if this is the last page.")
+  val last: Boolean,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/controllers/SyncControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/controllers/SyncControllerTest.kt
@@ -11,6 +11,8 @@ import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.controllers.sync.SyncController
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.sync.GeneralLedgerEntry
@@ -207,16 +209,38 @@ class SyncControllerTest {
   @DisplayName("getGeneralLedgerTransactionsByDate")
   inner class GetGeneralLedgerTransactionsByDate {
     @Test
-    fun `should return a list of transactions and OK status`() {
+    fun `should return a list of transactions and OK status with pagination data`() {
       val startDate = LocalDate.of(2025, 1, 1)
       val endDate = LocalDate.of(2025, 1, 31)
       val transactions = listOf(generalLedgerTransactionResponse)
-      `when`(syncQueryService.getGeneralLedgerTransactionsByDate(startDate, endDate)).thenReturn(transactions)
-      val response = syncController.getGeneralLedgerTransactionsByDate(startDate, endDate)
+      val page = PageImpl(transactions, org.springframework.data.domain.PageRequest.of(0, 20), 1)
+
+      `when`(syncQueryService.getGeneralLedgerTransactionsByDate(startDate, endDate, 0, 20)).thenReturn(page)
+      val response = syncController.getGeneralLedgerTransactionsByDate(startDate, endDate, 0, 20)
+
       assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
       assertThat(response.body).isInstanceOf(SyncGeneralLedgerTransactionListResponse::class.java)
       assertThat(response.body?.transactions).hasSize(1)
       assertThat(response.body?.transactions).isEqualTo(transactions)
+      assertThat(response.body?.page).isEqualTo(0)
+      assertThat(response.body?.totalElements).isEqualTo(1)
+      assertThat(response.body?.totalPages).isEqualTo(1)
+      assertThat(response.body?.last).isTrue()
+    }
+
+    @Test
+    fun `should return an empty list and OK status when no transactions are found`() {
+      val startDate = LocalDate.of(2025, 1, 1)
+      val endDate = LocalDate.of(2025, 1, 31)
+      val emptyPage = Page.empty<SyncGeneralLedgerTransactionResponse>()
+
+      `when`(syncQueryService.getGeneralLedgerTransactionsByDate(startDate, endDate, 0, 20)).thenReturn(emptyPage)
+      val response = syncController.getGeneralLedgerTransactionsByDate(startDate, endDate, 0, 20)
+
+      assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+      assertThat(response.body).isInstanceOf(SyncGeneralLedgerTransactionListResponse::class.java)
+      assertThat(response.body?.transactions).isEmpty()
+      assertThat(response.body?.totalElements).isEqualTo(0)
     }
   }
 
@@ -224,27 +248,38 @@ class SyncControllerTest {
   @DisplayName("getOffenderTransactionsByDate")
   inner class GetOffenderTransactionsByDate {
     @Test
-    fun `should return a list of offender transactions and OK status`() {
+    fun `should return a list of offender transactions and OK status with pagination data`() {
       val startDate = LocalDate.of(2025, 1, 1)
       val endDate = LocalDate.of(2025, 1, 31)
       val transactions = listOf(offenderTransactionResponse)
-      `when`(syncQueryService.getOffenderTransactionsByDate(startDate, endDate)).thenReturn(transactions)
-      val response = syncController.getOffenderTransactionsByDate(startDate, endDate)
+      val page = PageImpl(transactions, org.springframework.data.domain.PageRequest.of(0, 20), 1)
+
+      `when`(syncQueryService.getOffenderTransactionsByDate(startDate, endDate, 0, 20)).thenReturn(page)
+      val response = syncController.getOffenderTransactionsByDate(startDate, endDate, 0, 20)
+
       assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
       assertThat(response.body).isInstanceOf(SyncOffenderTransactionListResponse::class.java)
       assertThat(response.body?.offenderTransactions).hasSize(1)
       assertThat(response.body?.offenderTransactions).isEqualTo(transactions)
+      assertThat(response.body?.page).isEqualTo(0)
+      assertThat(response.body?.totalElements).isEqualTo(1)
+      assertThat(response.body?.totalPages).isEqualTo(1)
+      assertThat(response.body?.last).isTrue()
     }
 
     @Test
     fun `should return an empty list and OK status when no offender transactions are found`() {
       val startDate = LocalDate.of(2025, 1, 1)
       val endDate = LocalDate.of(2025, 1, 31)
-      `when`(syncQueryService.getOffenderTransactionsByDate(startDate, endDate)).thenReturn(emptyList())
-      val response = syncController.getOffenderTransactionsByDate(startDate, endDate)
+      val emptyPage = Page.empty<SyncOffenderTransactionResponse>()
+
+      `when`(syncQueryService.getOffenderTransactionsByDate(startDate, endDate, 0, 20)).thenReturn(emptyPage)
+      val response = syncController.getOffenderTransactionsByDate(startDate, endDate, 0, 20)
+
       assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
       assertThat(response.body).isInstanceOf(SyncOffenderTransactionListResponse::class.java)
       assertThat(response.body?.offenderTransactions).isEmpty()
+      assertThat(response.body?.totalElements).isEqualTo(0)
     }
   }
 


### PR DESCRIPTION
Add paging the following endpoints that retrieve transactions by a date range

GET /sync/general-ledger-transactions: Retrieves a list of General Ledger transactions.

GET /sync/offender-transactions: Retrieves a list of Offender transactions.