### PR TITLE
Align prisonId length with nomis

### DIFF
--- a/src/main/resources/db/migrations/V1_13__AlignPrisonID_With_NOMIS.sql
+++ b/src/main/resources/db/migrations/V1_13__AlignPrisonID_With_NOMIS.sql
@@ -1,0 +1,5 @@
+ALTER TABLE migrated_general_ledger_balances
+ALTER COLUMN prison_id TYPE VARCHAR(24);
+
+ALTER TABLE prison
+ALTER COLUMN code TYPE VARCHAR(24);


### PR DESCRIPTION
Align the prisonId length with the 24 chars of NOMIS

We are getting errors from the migration

```
org.springframework.dao.DataIntegrityViolationException: could not execute statement [ERROR: value too long for type character varying(3)] [insert into migrated_general_ledger_balances (body,prison_id,timestamp) values (?,?,?)]; SQL [insert into migrated_general_ledger_balances (body,prison_id,timestamp) values (?,?,?)]
```