### PR TITLE
Persist the prison id for each transaction

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/jpa/entities/Transaction.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/jpa/entities/Transaction.kt
@@ -33,4 +33,7 @@ data class Transaction(
 
   @Column(name = "synchronized_transaction_id")
   val synchronizedTransactionId: UUID? = null,
+
+  @Column(name = "prison")
+  val prison: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/services/ledger/LedgerSyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/services/ledger/LedgerSyncService.kt
@@ -55,6 +55,7 @@ open class LedgerSyncService(
         transactionTimestamp = transactionTimestamp,
         legacyTransactionId = request.transactionId,
         synchronizedTransactionId = synchronizedTransactionId,
+        request.caseloadId,
       )
     }
 
@@ -90,6 +91,7 @@ open class LedgerSyncService(
       transactionTimestamp = transactionTimestamp,
       legacyTransactionId = request.transactionId,
       synchronizedTransactionId = synchronizedTransactionId,
+      request.caseloadId,
     )
 
     return synchronizedTransactionId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/services/ledger/TransactionService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/services/ledger/TransactionService.kt
@@ -31,6 +31,7 @@ open class TransactionService(
     transactionTimestamp: Instant? = null,
     legacyTransactionId: Long? = null,
     synchronizedTransactionId: UUID? = null,
+    prison: String,
   ): Transaction {
     if (entries.isEmpty()) {
       throw IllegalArgumentException("Transaction must have at least one entry.")
@@ -51,6 +52,7 @@ open class TransactionService(
       date = timestamp,
       legacyTransactionId = legacyTransactionId,
       synchronizedTransactionId = synchronizedTransactionId,
+      prison = prison,
     )
     val savedTransaction = transactionRepository.save(transaction)
     val savedEntries = mutableListOf<TransactionEntry>()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/services/migration/MigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/services/migration/MigrationService.kt
@@ -91,6 +91,7 @@ open class MigrationService(
             description = "General Ledger Point-in-Time Balance Sync",
             entries = allEntries,
             transactionTimestamp = transactionTimestamp,
+            prison = prisonId,
           )
         }
       }
@@ -101,9 +102,8 @@ open class MigrationService(
     requestCaptureService.capturePrisonerMigrationRequest(prisonNumber, request)
 
     request.accountBalances.forEach { balanceData ->
-      val prisonCode = balanceData.prisonId
-      val prison = prisonService.getPrison(prisonCode)
-        ?: prisonService.createPrison(prisonCode)
+      val prison = prisonService.getPrison(balanceData.prisonId)
+        ?: prisonService.createPrison(balanceData.prisonId)
       val clearingAccount = accountService.findGeneralLedgerAccount(
         prisonId = prison.id!!,
         accountCode = 9999,
@@ -142,6 +142,7 @@ open class MigrationService(
           description = "Prisoner Balance Migration",
           entries = availableEntries,
           transactionTimestamp = transactionTimestamp,
+          prison = balanceData.prisonId,
         )
       }
 
@@ -155,6 +156,7 @@ open class MigrationService(
           description = "Prisoner Hold Balance Migration",
           entries = holdEntries,
           transactionTimestamp = transactionTimestamp,
+          prison = balanceData.prisonId,
         )
       }
     }

--- a/src/main/resources/db/migrations/common/V1_15__AddPrisonIdToTransaction.sql
+++ b/src/main/resources/db/migrations/common/V1_15__AddPrisonIdToTransaction.sql
@@ -1,0 +1,2 @@
+ALTER TABLE transaction
+    ADD COLUMN prison VARCHAR(24);


### PR DESCRIPTION
Persist the prisonId (e.g. LEI) within the transaction table. This column is set as nullable to maintain compatibility with existing historical data.