### PR TITLE
Address issues with the swagger docs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/config/OpenApiConfiguration.kt
@@ -33,8 +33,8 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
     .tags(apiTags())
 
   private fun serviceServers(): List<Server> = listOf(
-    Server().url("http://localhost:8080").description("Local development environment"),
-    Server().url("https://prisoner-finance-poc-api-dev.hmpps.service.justice.gov.uk/").description("Development environment"),
+    Server().url("https://prisoner-finance-poc-api-dev.hmpps.service.justice.gov.uk/").description("Development"),
+    Server().url("http://localhost:8080").description("Local"),
   )
 
   private fun apiInfo(): Info = Info()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/controllers/PrisonAccountsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/controllers/PrisonAccountsController.kt
@@ -19,8 +19,8 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.resource.NoResourceFoundException
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.config.ROLE_PRISONER_FINANCE_SYNC
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.config.TAG_PRISON_ACCOUNTS
-import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.AccountDetailsList
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.PrisonAccountDetails
+import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.PrisonAccountDetailsList
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.TransactionDetailsList
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.services.ledger.LedgerQueryService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
@@ -80,16 +80,16 @@ class PrisonAccountsController(
   )
   @ApiResponses(
     value = [
-      ApiResponse(responseCode = "200", description = "OK", content = [Content(schema = Schema(implementation = AccountDetailsList::class))]),
+      ApiResponse(responseCode = "200", description = "OK", content = [Content(schema = Schema(implementation = PrisonAccountDetailsList::class))]),
     ],
   )
   @SecurityRequirement(name = "bearer-jwt", scopes = [ROLE_PRISONER_FINANCE_SYNC])
   @PreAuthorize("hasAnyAuthority('$ROLE_PRISONER_FINANCE_SYNC')")
   fun listPrisonAccounts(
     @PathVariable prisonId: String,
-  ): ResponseEntity<AccountDetailsList> {
+  ): ResponseEntity<PrisonAccountDetailsList> {
     val items = ledgerQueryService.listPrisonAccountDetails(prisonId)
-    val body = AccountDetailsList(items)
+    val body = PrisonAccountDetailsList(items)
     return ResponseEntity.ok(body)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/controllers/PrisonerAccountsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/controllers/PrisonerAccountsController.kt
@@ -18,8 +18,8 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.resource.NoResourceFoundException
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.config.ROLE_PRISONER_FINANCE_SYNC
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.config.TAG_PRISONER_ACCOUNTS
-import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.AccountDetailsList
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.PrisonerSubAccountDetails
+import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.PrisonerSubAccountDetailsList
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models.TransactionDetailsList
 import uk.gov.justice.digital.hmpps.prisonerfinancepocapi.services.ledger.LedgerQueryService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
@@ -79,16 +79,16 @@ class PrisonerAccountsController(
   )
   @ApiResponses(
     value = [
-      ApiResponse(responseCode = "200", description = "OK", content = [Content(schema = Schema(implementation = AccountDetailsList::class))]),
+      ApiResponse(responseCode = "200", description = "OK", content = [Content(schema = Schema(implementation = PrisonerSubAccountDetailsList::class))]),
     ],
   )
   @SecurityRequirement(name = "bearer-jwt", scopes = [ROLE_PRISONER_FINANCE_SYNC])
   @PreAuthorize("hasAnyAuthority('$ROLE_PRISONER_FINANCE_SYNC')")
   fun listPrisonerAccounts(
     @PathVariable prisonNumber: String,
-  ): ResponseEntity<AccountDetailsList> {
+  ): ResponseEntity<PrisonerSubAccountDetailsList> {
     val items = ledgerQueryService.listPrisonerSubAccountDetails(prisonNumber)
-    val body = AccountDetailsList(items)
+    val body = PrisonerSubAccountDetailsList(items)
     return ResponseEntity.ok(body)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/AccountDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/AccountDetails.kt
@@ -7,5 +7,3 @@ interface AccountDetails {
   val name: String
   val balance: BigDecimal
 }
-
-data class AccountDetailsList(val items: List<AccountDetails>)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/PrisonAccountDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/PrisonAccountDetails.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models
 import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
 
-@Schema(description = "Summary of an prison general ledger account")
+@Schema(description = "Summary of a prison general ledger account")
 data class PrisonAccountDetails(
   @field:Schema(description = "The unique numeric code identifying the prison general ledger account.", example = "1000")
   override val code: Int,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/PrisonAccountDetailsList.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/PrisonAccountDetailsList.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "A list of accounts for a specific prison")
+data class PrisonAccountDetailsList(val items: List<PrisonAccountDetails>)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/PrisonerSubAccountDetailsList.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/prisonerfinancepocapi/models/PrisonerSubAccountDetailsList.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.prisonerfinancepocapi.models
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "A list of prisoner sub-accounts (e.g., Cash, Spends, Savings)")
+data class PrisonerSubAccountDetailsList(val items: List<PrisonerSubAccountDetails>)


### PR DESCRIPTION
Improve the Swagger API documentation by: 
- returning dedicated types for both `/prisoner` and `/prisons` GET endpoints.
- Make dev the default server